### PR TITLE
Guard optional sync payload sends by channel negotiation

### DIFF
--- a/neoforge/src/main/java/cc/abbie/emi_ores/neoforge/EmiOresNeoForge.java
+++ b/neoforge/src/main/java/cc/abbie/emi_ores/neoforge/EmiOresNeoForge.java
@@ -14,6 +14,7 @@ import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
 
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class EmiOresNeoForge {
         List<ServerPlayer> players = event.getPlayer() == null ? event.getPlayerList().getPlayers() : List.of(event.getPlayer());
         players.forEach(player -> FeaturesSender.onSyncDataPackContents(
                 player,
-                (p, t) -> true,
+                (p, t) -> NetworkRegistry.hasChannel(p.connection, t.id()),
                 PacketDistributor::sendToPlayer
         ));
     }


### PR DESCRIPTION
## Summary
- avoid sending `emi_ores` datapack sync payloads to clients that did not negotiate `emi_ores` channels
- use `NetworkRegistry.hasChannel(player.connection, payloadType.id())` in `EmiOresNeoForge.onDatapackSync`
- preserve existing behavior for clients that do have EMI Ores installed

## Test plan
- [x] Build NeoForge artifact with `./gradlew :neoforge:build`
- [x] Confirm generated bytecode now calls `NetworkRegistry.hasChannel(...)` inside the datapack sync predicate
- [ ] Dedicated server: client without EMI Ores can join without `Payload ... may not be sent to the client!`
- [ ] Dedicated/LAN: client with EMI Ores still receives ore generation data in EMI